### PR TITLE
Update clipboard.rs

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,20 +1,32 @@
-use copypasta::{ClipboardContext, ClipboardProvider};
-use std::{thread, time::Duration};
+use std::sync::mpsc::{self, Sender, Receiver};
+use std::{thread::{self, JoinHandle}, time::Duration};
+use copypasta::{ClipboardContext, ClipboardError, ClipboardProvider};
 
-pub fn monitor_clipboard<F: Fn(String) + Send + 'static>(on_change: F) {
-    thread::spawn(move || {
-        let mut ctx = ClipboardContext::new().unwrap();
+pub fn monitor_clipboard<F>(on_change: F) -> Result<(Sender<()>, JoinHandle<()>), ClipboardError>
+where
+    F: Fn(String) + Send + 'static,
+{
+    let (stop_tx, stop_rx): (Sender<()>, Receiver<()>) = mpsc::channel();
+    let mut ctx = ClipboardContext::new()?;
+    let handle = thread::spawn(move || {
         let mut last_clip = String::new();
-
         loop {
-            if let Ok(current) = ctx.get_contents() {
-                if current != last_clip && !current.trim().is_empty() {
-                    on_change(current.clone());
-                    last_clip = current;
+            if stop_rx.try_recv().is_ok() {
+                break;
+            }
+            match ctx.get_contents() {
+                Ok(current) => {
+                    if current != last_clip && !current.trim().is_empty() {
+                        on_change(current.clone());
+                        last_clip = current;
+                    }
+                }
+                Err(err) => {
+                    eprintln!("clipboard error: {:?}", err);
                 }
             }
-
             thread::sleep(Duration::from_millis(500));
         }
     });
+    Ok((stop_tx, handle))
 }


### PR DESCRIPTION
Replaced unwrap() on ClipboardContext::new() with ? to prevent panics and surface initialization errors.

Introduced an mpsc::Sender<()>/Receiver<()> stop channel returned alongside the JoinHandle so callers can signal the monitoring thread to exit.

Switched to match ctx.get_contents() with eprintln! on errors to ensure clipboard read failures are visible rather than silently ignored.